### PR TITLE
Add support for Augmentation Evoker Blistering Scales

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -7,6 +7,7 @@ config.misdirectSpells = {
 	["HUNTER"] = 34477,
 	["ROGUE"] = 57934,
 	["DRUID"] = 29166,
+	["EVOKER"] = 360827,
 }
 
 -- Key is the target's index (first target found, second target found, etc.)
@@ -32,4 +33,5 @@ config.targets = {
 	["HUNTER"] = "TANK",
 	["ROGUE"] = "TANK",
 	["DRUID"] = "HEALER",
+	["EVOKER"] = "TANK",
 }

--- a/Core.lua
+++ b/Core.lua
@@ -26,7 +26,16 @@ function addon:CreateButtons()
 	local _, class = UnitClass("player")
 	local spell = self.config.misdirectSpells[class]
 	local role = self.config.targets[class]
-	local targetMatcher = class == "HUNTER" and addon:CreateRoleOrPetTargetMatcher(role) or addon:CreateRoleTargetMatcher(role)
+	
+	local targetMatcher = nil
+	if class == "HUNTER" then
+		targetMatcher = addon:CreateRoleOrPetTargetMatcher(role)
+	elseif class == "EVOKER" then
+		targetMatcher = addon:CreateRoleOrSelfTargetMatcher(role)
+	else
+		targetMatcher = addon:CreateRoleTargetMatcher(role)
+	end
+
 	for i, buttonName in pairs(self.config.misdirectButtons) do
 		local button = self:CreateMisdirectButton(buttonName, spell, i, targetMatcher)
 		tinsert(self.buttons, button)

--- a/TankMD.toc
+++ b/TankMD.toc
@@ -1,7 +1,7 @@
 ## Interface: 100105
 ## Interface-Wrath: 30402
 ## Title: TankMD
-## Notes: One button to always misdirect to the tank. Also supports Tricks for rogues, and Innervate for druids (targets healers).
+## Notes: One button to always misdirect to the tank. Also supports Tricks for rogues, Blistering Scales for evokers and Innervate for druids (targets healers).
 ## Author: Oppzippy
 ## Version: @project-version@
 ## OptionalDeps: Ace3

--- a/TargetMatcher/RoleOrSelfTargetMatcher.lua
+++ b/TargetMatcher/RoleOrSelfTargetMatcher.lua
@@ -1,0 +1,18 @@
+local _, addon = ...
+local RoleOrSelfTargetMatcherPrototype = setmetatable({}, addon.RoleTargetMatcherPrototype)
+addon.RoleOrSelfTargetMatcherPrototype = RoleOrSelfTargetMatcherPrototype
+RoleOrSelfTargetMatcherPrototype.__index = RoleOrSelfTargetMatcherPrototype
+
+function addon:CreateRoleOrSelfTargetMatcher(role)
+	local targetMatcher = setmetatable({}, RoleOrSelfTargetMatcherPrototype)
+	targetMatcher.role = role
+	return targetMatcher
+end
+
+function RoleOrSelfTargetMatcherPrototype:FindTargets()
+	local targets = addon.RoleTargetMatcherPrototype.FindTargets(self)
+	if #targets == 0 then
+		return {"player"}
+	end
+	return targets
+end

--- a/TargetMatcher/TargetMatchers.xml
+++ b/TargetMatcher/TargetMatchers.xml
@@ -3,4 +3,5 @@
 	<Script file="TargetMatcher.lua"/>
 	<Script file="RoleTargetMatcher.lua"/>
 	<Script file="RoleOrPetTargetMatcher.lua"/>
+	<Script file="RoleOrSelfTargetMatcher.lua"/>
 </Ui>


### PR DESCRIPTION
The new Augmentation Evoker spec has a spell called "Blistering Scales" which ideally should be cast on a tank, but it can be cast on any friendly target.  I've added support for this new spell.

 - I added a new `RoleOrSelfTargetMatcher` which will simply target the desired role first, or the player (self) otherwise.  I did this because the buff is nice to cast on yourself when solo.
 - I added the appropriate spell and class configs.
 - I modified the default target matcher setup to add support for evoker.

I love this addon, and I thought this might be useful to others!  I did a heroic dungeon to test this, and it worked as expected.

Cheers!