### PR TITLE
Role priority

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -24,6 +24,7 @@ config.misdirectButtons = {
 config.queueEvents = {
 	["GROUP_ROSTER_UPDATE"] = true,
 	["PLAYER_ENTERING_WORLD"] = true,
+	["PLAYER_FOCUS_CHANGED"] = true,
 }
 
 -- Events which update the tank if an update is queued

--- a/TargetMatcher/RoleTargetMatcher.lua
+++ b/TargetMatcher/RoleTargetMatcher.lua
@@ -13,9 +13,18 @@ function addon:CreateRoleTargetMatcher(role)
 end
 
 function RoleTargetMatcherPrototype:Matches(unit)
+	if UnitIsDeadOrGhost(unit) then return false end
 	local role = UnitGroupRolesAssigned(unit)
-	if role ~= "NONE" then
-		return self.role == role
+	local raidTank = GetPartyAssignment("MAINTANK",unit)
+	local focus = UnitExists("focus") and UnitIsUnit(unit,"focus")
+	if focus then
+		return true
+	elseif role ~= "NONE" then
+		if IsInRaid() then
+			return (self.role == "TANK") and raidTank or (self.role == role)
+		else
+			return self.role == role
+		end
 	elseif LGIST then
 		local guid = UnitGUID(unit)
 		local inspectInfo = LGIST:GetCachedInfo(guid)


### PR DESCRIPTION
More of a discussion PR, although I have been running it for a couple months on my hunter.

The general idea is to let me (players) have more control over the recipient (of MD in my case) without having to take up more - precious - keybinding space.

Again this is mostly about raids or premade groups, the addon works fine in its current iteration for machine formed 5mans where there's only one of tank/healer.

In a raid it's very easy to have it target an unintended player. The MT for one fight will not be the same as the MT for another, relying on alphabetic order or worse simply role setting is not workable.

This changes the sorting of valid targets to follow a - hardcoded for now - priority system.
Taking MD as an example:
1. Focus if one is set
2. Raid Tank (role tank + set as main tank) - alphabetically
3. Role Tank - alphabetically
4. Pet
falling through