### PR TITLE
Configure the actionbutton to always run on down

### DIFF
--- a/MisdirectButton.lua
+++ b/MisdirectButton.lua
@@ -19,6 +19,7 @@ local function createButton(name, spell)
 	button:SetAttribute("checkselfcast", false)
 	button:SetAttribute("checkfocuscast", false)
 	button:SetAttribute("allowVehicleTarget", false)
+	button:SetAttribute("pressAndHoldAction", "1") -- Ensures the action always fires on Down, regardless of the ActionButtonUseKeyDown cvar
 	button:RegisterForClicks("LeftButtonDown", "LeftButtonUp")
 	return button
 end


### PR DESCRIPTION
This lets you use `/click TankMDButton1 LeftButton 0` regardless of what the ActionButtonUseKeyDown CVar is set to
`/click TankMDButton1 LeftButton 1` is then no longer necessary