### PR TITLE
Added support for Paladin's Blessing of Freedom

### DIFF
--- a/ClassTargetSelectors.lua
+++ b/ClassTargetSelectors.lua
@@ -61,6 +61,10 @@ function ClassTargetSelectors.ROGUE()
 	return chainWithFocus(getTankSelector(addon.db.profile.tankSelectionMethod))
 end
 
+function ClassTargetSelectors.PALADIN()
+	return chainWithFocus(getTankSelector(addon.db.profile.tankSelectionMethod))
+end
+
 function ClassTargetSelectors.EVOKER()
 	return chainWithFocus(TargetSelector.Chain({
 		getTankSelector(addon.db.profile.tankSelectionMethod),

--- a/TankMD.lua
+++ b/TankMD.lua
@@ -111,6 +111,7 @@ do
 		["ROGUE"] = 57934,
 		["DRUID"] = 29166,
 		["EVOKER"] = 360827,
+		["PALADIN"] = 1044,
 	}
 
 	---@param class string
@@ -127,6 +128,7 @@ do
 		["ROGUE"] = "TANK",
 		["DRUID"] = "HEALER",
 		["EVOKER"] = "TANK",
+		["PALADIN"] = "TANK",
 	}
 
 	---@param class string


### PR DESCRIPTION
As mentioned in this post(https://bbs.nga.cn/read.php?tid=36379726).
In the Mythic+ dungeon, the Retribution Paladin often needs to cast Blessing of Freedom on the tank to ensure that the tank does not need to run around.
For example, when the Entangled Affix is ​​triggered, or when the monster is casting such skills(https://www.wowhead.com/spell=370766/crystalline-rupture).
In addition, when the tank is gathering monsters, the Retribution Paladin will also cast Blessing of Freedom on the tank. Because when the Unbound Freedom talent is selected, Blessing of Freedom has a speed-up effect, which is beneficial for the tank to gather monsters.